### PR TITLE
Fixing broken sound

### DIFF
--- a/Opensegaapi/src/opensegaapi.cpp
+++ b/Opensegaapi/src/opensegaapi.cpp
@@ -475,11 +475,14 @@ static void updateBufferNew(OPEN_segaapiBuffer_t* buffer, unsigned int offset, s
 }
 
 extern "C" {
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_CreateBuffer(OPEN_HAWOSEBUFFERCONFIG* pConfig, OPEN_HAWOSEGABUFFERCALLBACK pCallback, unsigned int dwFlags, void* * phHandle)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_CreateBuffer(OPEN_HAWOSEBUFFERCONFIG* pConfig, OPEN_HAWOSEGABUFFERCALLBACK pCallback, unsigned int dwFlags, void* * phHandle)
 	{
-		if ((phHandle == NULL) || (pConfig == NULL))
+		if (phHandle == NULL || pConfig == NULL)
 		{
-			return OPENSEGAERR_BAD_POINTER;
+#ifdef _DEBUG
+			info("SEGAAPI_CreateBuffer: Handle: %08X, Status: OPEN_SEGAERR_BAD_POINTER", phHandle);
+#endif
+			return OPEN_SEGAERR_BAD_POINTER;
 		}
 
 		OPEN_segaapiBuffer_t* buffer = new OPEN_segaapiBuffer_t;
@@ -544,11 +547,14 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetUserData(void* hHandle, void* hUserData)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetUserData(void* hHandle, void* hUserData)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_SetUserData: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -576,11 +582,14 @@ extern "C" {
 		return buffer->userData;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_UpdateBuffer(void* hHandle, unsigned int dwStartOffset, unsigned int dwLength)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_UpdateBuffer(void* hHandle, unsigned int dwStartOffset, unsigned int dwLength)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_UpdateBuffer: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -593,11 +602,14 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetEndOffset(void* hHandle, unsigned int dwOffset)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetEndOffset(void* hHandle, unsigned int dwOffset)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_SetEndOffset: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -609,11 +621,14 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetEndLoopOffset(void* hHandle, unsigned int dwOffset)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetEndLoopOffset(void* hHandle, unsigned int dwOffset)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_SetEndLoopOffset: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -625,11 +640,14 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetStartLoopOffset(void* hHandle, unsigned int dwOffset)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetStartLoopOffset(void* hHandle, unsigned int dwOffset)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_SetStartLoopOffset: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -641,11 +659,14 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSampleRate(void* hHandle, unsigned int dwSampleRate)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSampleRate(void* hHandle, unsigned int dwSampleRate)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_SetSampleRate: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -663,15 +684,18 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetLoopState(void* hHandle, int bDoContinuousLooping)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetLoopState(void* hHandle, int bDoContinuousLooping)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_SetLoopState: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
-		info("SEGAAPI_SetLoopState: Handle: %08X dwSampleRate: %08X", hHandle, bDoContinuousLooping);
+		info("SEGAAPI_SetLoopState: Handle: %08X bDoContinuousLooping: %d", hHandle, bDoContinuousLooping);
 #endif
 
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
@@ -680,11 +704,14 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetPlaybackPosition(void* hHandle, unsigned int dwPlaybackPos)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetPlaybackPosition(void* hHandle, unsigned int dwPlaybackPos)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_SetPlaybackPosition: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -724,11 +751,14 @@ extern "C" {
 
 	static void updateRouting(OPEN_segaapiBuffer_t* buffer);
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Play(void* hHandle)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Play(void* hHandle)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_Play: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -752,11 +782,14 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Stop(void* hHandle)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Stop(void* hHandle)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_Stop: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -775,9 +808,9 @@ extern "C" {
 		if (hHandle == NULL)
 		{
 #ifdef _DEBUG
-			info("SEGAAPI_GetPlaybackStatus: Handle: %08X, Status: OPENSEGAERR_BAD_HANDLE", hHandle);
+			info("SEGAAPI_GetPlaybackStatus: Handle: %08X, Status: OPEN_HAWOSTATUS_INVALID", hHandle);
 #endif
-			return OPEN_HAWOSTATUS(OPENSEGAERR_BAD_HANDLE);
+			return OPEN_HAWOSTATUS_INVALID;
 		}
 
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
@@ -825,11 +858,14 @@ extern "C" {
 		}
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetReleaseState(void* hHandle, int bSet)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetReleaseState(void* hHandle, int bSet)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_SetReleaseState: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -847,11 +883,14 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_DestroyBuffer(void* hHandle)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_DestroyBuffer(void* hHandle)
 	{
 		if (hHandle == NULL)
 		{
-			return OPENSEGAERR_BAD_HANDLE;
+#ifdef _DEBUG
+			info("SEGAAPI_DestroyBuffer: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
 		}
 
 #ifdef _DEBUG
@@ -875,9 +914,8 @@ extern "C" {
 		return TRUE;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Init(void)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Init(void)
 	{
-
 #ifdef _DEBUG
 		info("SEGAAPI_Init");
 #endif
@@ -932,7 +970,7 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Exit(void)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Exit(void)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_Exit");
@@ -946,7 +984,7 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Reset(void)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Reset(void)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_Reset");
@@ -954,7 +992,7 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetIOVolume(OPEN_HAPHYSICALIO dwPhysIO, unsigned int dwVolume)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetIOVolume(OPEN_HAPHYSICALIO dwPhysIO, unsigned int dwVolume)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_SetIOVolume: dwPhysIO: %08X dwVolume: %08X", dwPhysIO, dwVolume);
@@ -1014,11 +1052,20 @@ extern "C" {
 		}
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSendRouting(void* hHandle, unsigned int dwChannel, unsigned int dwSend, OPEN_HAROUTING dwDest)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSendRouting(void* hHandle, unsigned int dwChannel, unsigned int dwSend, OPEN_HAROUTING dwDest)
 	{
+		if (hHandle == NULL)
+		{
+#ifdef _DEBUG
+			info("SEGAAPI_SetSendRouting: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
+		}
+
 #ifdef _DEBUG
 		info("SEGAAPI_SetSendRouting: hHandle: %08X dwChannel: %08X dwSend: %08X dwDest: %08X", hHandle, dwChannel, dwSend, dwDest);
 #endif
+
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
 		buffer->sendRoutes[dwSend] = dwDest;
 		buffer->sendChannels[dwSend] = dwChannel;
@@ -1027,11 +1074,20 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSendLevel(void* hHandle, unsigned int dwChannel, unsigned int dwSend, unsigned int dwLevel)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSendLevel(void* hHandle, unsigned int dwChannel, unsigned int dwSend, unsigned int dwLevel)
 	{
+		if (hHandle == NULL)
+		{
+#ifdef _DEBUG
+			info("SEGAAPI_SetSendLevel: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
+		}
+
 #ifdef _DEBUG
 		info("SEGAAPI_SetSendLevel: hHandle: %08X dwChannel: %08X dwSend: %08X dwLevel: %08X", hHandle, dwChannel, dwSend, dwLevel);
 #endif
+
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
 		buffer->sendVolumes[dwSend] = dwLevel / (float)0xFFFFFFFF;
 		buffer->sendChannels[dwSend] = dwChannel;
@@ -1040,11 +1096,20 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSynthParam(void* hHandle, OPEN_HASYNTHPARAMSEXT param, int lPARWValue)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSynthParam(void* hHandle, OPEN_HASYNTHPARAMSEXT param, int lPARWValue)
 	{
+		if (hHandle == NULL)
+		{
+#ifdef _DEBUG
+			info("SEGAAPI_SetSynthParam: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
+		}
+
 #ifdef _DEBUG
 		info("SEGAAPI_SetSynthParam: hHandle: %08X OPEN_HASYNTHPARAMSEXT: %08X lPARWValue: %08X", hHandle, param, lPARWValue);
 #endif
+
 		enum
 		{
 			StartAddrsOffset,
@@ -1171,17 +1236,35 @@ extern "C" {
 
 	__declspec(dllexport) int SEGAAPI_GetSynthParam(void * hHandle, OPEN_HASYNTHPARAMSEXT param)
 	{
+		if (hHandle == NULL)
+		{
+#ifdef _DEBUG
+			info("SEGAAPI_GetSynthParam: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
+		}
+
 #ifdef _DEBUG
 		info("SEGAAPI_GetSynthParam: hHandle: %08X OPEN_HASYNTHPARAMSEXT: %08X", hHandle, param);
 #endif
+
 		return 0; //todo not sure if actually used
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSynthParamMultiple(void* hHandle, unsigned int dwNumParams, OPEN_SynthParamSet* pSynthParams)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSynthParamMultiple(void* hHandle, unsigned int dwNumParams, OPEN_SynthParamSet* pSynthParams)
 	{
+		if (hHandle == NULL)
+		{
+#ifdef _DEBUG
+			info("SEGAAPI_SetSynthParamMultiple: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
+		}
+
 #ifdef _DEBUG
 		info("SEGAAPI_SetSynthParamMultiple: hHandle: %08X dwNumParams: %08X pSynthParams: %08X", hHandle, dwNumParams, pSynthParams);
 #endif
+
 		for (int i = 0; i < dwNumParams; i++)
 		{
 			SEGAAPI_SetSynthParam(hHandle, pSynthParams[i].param, pSynthParams[i].lPARWValue);
@@ -1189,11 +1272,20 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetChannelVolume(void* hHandle, unsigned int dwChannel, unsigned int dwVolume)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetChannelVolume(void* hHandle, unsigned int dwChannel, unsigned int dwVolume)
 	{
+		if (hHandle == NULL)
+		{
+#ifdef _DEBUG
+			info("SEGAAPI_SetChannelVolume: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
+		}
+
 #ifdef _DEBUG
 		info("SEGAAPI_SetChannelVolume: hHandle: %08X dwChannel: %08X dwVolume: %08X", hHandle, dwChannel, dwVolume);
 #endif
+
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
 		buffer->channelVolumes[dwChannel] = dwVolume / (float)0xFFFFFFFF;
 		return OPEN_SEGA_SUCCESS;
@@ -1201,18 +1293,36 @@ extern "C" {
 
 	__declspec(dllexport) unsigned int SEGAAPI_GetChannelVolume(void* hHandle, unsigned int dwChannel)
 	{
+		if (hHandle == NULL)
+		{
+#ifdef _DEBUG
+			info("SEGAAPI_GetChannelVolume: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
+		}
+
 #ifdef _DEBUG
 		info("SEGAAPI_GetChannelVolume: hHandle: %08X dwChannel: %08X", hHandle, dwChannel);
 #endif
+
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
 		return buffer->channelVolumes[dwChannel];
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Pause(void* hHandle)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Pause(void* hHandle)
 	{
+		if (hHandle == NULL)
+		{
+#ifdef _DEBUG
+			info("SEGAAPI_Pause: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
+		}
+
 #ifdef _DEBUG
 		info("SEGAAPI_Pause: hHandle: %08X", hHandle);
 #endif
+
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
 
 		buffer->playing = false;
@@ -1221,7 +1331,7 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_PlayWithSetup(
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_PlayWithSetup(
 		void* hHandle,
 		unsigned int dwNumSendRouteParams, OPEN_SendRouteParamSet* pSendRouteParams,
 		unsigned int dwNumSendLevelParams, OPEN_SendLevelParamSet* pSendLevelParams,
@@ -1229,10 +1339,19 @@ extern "C" {
 		unsigned int dwNumSynthParams, OPEN_SynthParamSet* pSynthParams
 	)
 	{
+		if (hHandle == NULL)
+		{
+#ifdef _DEBUG
+			info("SEGAAPI_PlayWithSetup: Handle: %08X, Status: OPEN_SEGAERR_BAD_HANDLE", hHandle);
+#endif
+			return OPEN_SEGAERR_BAD_HANDLE;
+		}
+
 #ifdef _DEBUG
 		info("SEGAAPI_PlayWithSetup: hHandle: %08X dwNumSendRouteParams: %d pSendRouteParams: %08X dwNumSendLevelParams: %d pSendLevelParams: %08X dwNumVoiceParams: %d pVoiceParams: %08X dwNumSynthParams: %d pSynthParams: %08X", hHandle, dwNumSendRouteParams, *pSendRouteParams, dwNumSendLevelParams, *pSendLevelParams, dwNumVoiceParams, *pVoiceParams, dwNumSynthParams, *pSynthParams);
 		info("dwNumSynthParams: %d", dwNumSynthParams);
 #endif
+
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
 		buffer->playWithSetup = true;
 
@@ -1303,7 +1422,7 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_GetLastStatus(void)
+	__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_GetLastStatus(void)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_GetLastStatus");

--- a/Opensegaapi/src/opensegaapi.cpp
+++ b/Opensegaapi/src/opensegaapi.cpp
@@ -865,7 +865,7 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	int SEGAAPI_SetGlobalEAXProperty(GUID * guid, unsigned long ulProperty, void * pData, unsigned long ulDataSize)
+	__declspec(dllexport) int SEGAAPI_SetGlobalEAXProperty(GUID * guid, unsigned long ulProperty, void * pData, unsigned long ulDataSize)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_SetGlobalEAXProperty:");
@@ -879,7 +879,7 @@ extern "C" {
 	{
 
 #ifdef _DEBUG
-		info("SEGAAPI_Init: hello harmfull world");
+		info("SEGAAPI_Init");
 #endif
 
 		CoInitialize(nullptr);
@@ -1169,7 +1169,7 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	int SEGAAPI_GetSynthParam(void * hHandle, OPEN_HASYNTHPARAMSEXT param)
+	__declspec(dllexport) int SEGAAPI_GetSynthParam(void * hHandle, OPEN_HASYNTHPARAMSEXT param)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_GetSynthParam: hHandle: %08X OPEN_HASYNTHPARAMSEXT: %08X", hHandle, param);
@@ -1290,7 +1290,7 @@ extern "C" {
 		}
 
 #ifdef _DEBUG
-		info("loopdata\t%08X\t%08X\t%08X\t%08X\t%d\t%d", hHandle, loopStart, loopEnd, endOffset, loopState, buffer->size);
+		info("Loopdata: hHandle: %08X, loopStart: %08X, loopEnd: %08X, endOffset: %08X, loopState: %d, size: %d", hHandle, loopStart, loopEnd, endOffset, loopState, buffer->size);
 #endif
 
 		for (int i = 0; i < dwNumSynthParams; i++)

--- a/Opensegaapi/src/opensegaapi.cpp
+++ b/Opensegaapi/src/opensegaapi.cpp
@@ -50,7 +50,7 @@ void info(const char* format, ...)
 	char buffer[1024];
 
 	va_start(args, format);
-	int len = _vsnprintf(buffer, sizeof(buffer), format, args);
+	int len = _vsnprintf_s(buffer, sizeof(buffer), format, args);
 	va_end(args);
 
 	buffer[len] = '\n';
@@ -109,6 +109,7 @@ struct OPEN_segaapiBuffer_t
 	size_t size;
 	bool playing;
 	bool paused;
+	bool playWithSetup;
 
 	WAVEFORMATEX xaFormat;
 
@@ -171,9 +172,12 @@ void defer_buffer_call(OPEN_segaapiBuffer_t* buffer, const TFn& fn)
 	fn();
 }
 
-static void dumpWaveBuffer(const char* path, unsigned int channels, unsigned int sampleRate, unsigned int sampleBits,
-	void* data, size_t size)
+static void dumpWaveBuffer(const char* path, unsigned int channels, unsigned int sampleRate, unsigned int sampleBits, void* data, size_t size)
 {
+#ifdef _DEBUG
+	info("dumpWaveBuffer path %s channels %d sampleRate %d sampleBits %d size %d", path, channels, sampleRate, sampleBits, size);
+#endif
+
 	struct RIFF_Header
 	{
 		char chunkID[4];
@@ -248,36 +252,6 @@ static void dumpWaveBuffer(const char* path, unsigned int channels, unsigned int
 static unsigned int bufferSampleSize(OPEN_segaapiBuffer_t* buffer)
 {
 	return buffer->channels * ((buffer->sampleFormat == OPEN_HASF_SIGNED_16PCM) ? 2 : 1);
-}
-
-static void updateBufferLoop(OPEN_segaapiBuffer_t* buffer)
-{
-	if (!buffer->defers.empty())
-	{
-		return;
-	}
-
-	CHECK_HR(buffer->xaVoice->FlushSourceBuffers());
-	buffer->xaBuffer.Flags = 0;
-	buffer->xaBuffer.AudioBytes = buffer->size;
-	buffer->xaBuffer.pAudioData = buffer->data;
-	buffer->xaBuffer.LoopCount = (buffer->loop) ? XAUDIO2_LOOP_INFINITE : 0;
-
-	if (buffer->loop)
-	{
-		buffer->xaBuffer.LoopBegin = buffer->startLoop / bufferSampleSize(buffer);
-		buffer->xaBuffer.LoopLength = (min(buffer->endLoop, buffer->endOffset) - buffer->startLoop) /
-			bufferSampleSize(buffer);
-		buffer->xaBuffer.PlayLength = 0;
-	}
-	else
-	{
-		buffer->xaBuffer.PlayLength = buffer->endOffset / bufferSampleSize(buffer);
-		buffer->xaBuffer.LoopBegin = 0;
-		buffer->xaBuffer.LoopLength = 0;
-	}
-
-	buffer->xaVoice->SubmitSourceBuffer(&buffer->xaBuffer);
 }
 
 static void updateSynthOnPlay(OPEN_segaapiBuffer_t* buffer, unsigned int offset, size_t length)
@@ -385,38 +359,6 @@ static void updateSynthOnPlay(OPEN_segaapiBuffer_t* buffer, unsigned int offset,
 	//}
 }
 
-static void updateBufferData(OPEN_segaapiBuffer_t* buffer, unsigned int offset, size_t length)
-{
-	// don't update with pending defers
-	if (!buffer->defers.empty())
-	{
-		return;
-	}
-
-	if (offset == -1)
-	{
-		CHECK_HR(buffer->xaVoice->FlushSourceBuffers());
-		buffer->xaBuffer.Flags = 0;
-		buffer->xaBuffer.AudioBytes = buffer->size;
-		buffer->xaBuffer.pAudioData = buffer->data;
-		buffer->xaBuffer.LoopCount = 0;
-		buffer->xaBuffer.LoopBegin = 0;
-		buffer->xaBuffer.LoopLength = 0;
-		buffer->xaVoice->SubmitSourceBuffer(&buffer->xaBuffer);
-	}
-	else
-	{
-		// restart with looping enabled
-		// this seems to make XA2 just reread the buffer, where criau put buffer data
-		CHECK_HR(buffer->xaVoice->FlushSourceBuffers());
-		buffer->xaBuffer.Flags = 0;
-		buffer->xaBuffer.AudioBytes = buffer->size;
-		buffer->xaBuffer.pAudioData = buffer->data;
-		buffer->xaBuffer.LoopCount = XAUDIO2_LOOP_INFINITE;
-		buffer->xaVoice->SubmitSourceBuffer(&buffer->xaBuffer);
-	}
-}
-
 static void resetBuffer(OPEN_segaapiBuffer_t* buffer)
 {
 	buffer->startLoop = 0;
@@ -424,6 +366,7 @@ static void resetBuffer(OPEN_segaapiBuffer_t* buffer)
 	buffer->endLoop = buffer->size;
 	buffer->loop = false;
 	buffer->paused = false;
+	buffer->playWithSetup = false;
 	buffer->sendRoutes[0] = OPEN_HA_FRONT_LEFT_PORT;
 	buffer->sendRoutes[1] = OPEN_HA_FRONT_RIGHT_PORT;
 	buffer->sendRoutes[2] = OPEN_HA_UNUSED_PORT;
@@ -478,21 +421,72 @@ static WRL::ComPtr<IXAudio2> g_xa2;
 static IXAudio2MasteringVoice* g_masteringVoice;
 static IXAudio2SubmixVoice* g_submixVoices[6];
 
+static void updateBufferNew(OPEN_segaapiBuffer_t* buffer, unsigned int offset, size_t length)
+{
+	// don't update with pending defers
+	if (!buffer->defers.empty())
+	{
+#ifdef _DEBUG
+		info("updateBufferNew: DEFER!");
+#endif
+		return;
+	}
+
+	CHECK_HR(buffer->xaVoice->FlushSourceBuffers());
+
+	buffer->xaBuffer.Flags = 0;
+	buffer->xaBuffer.AudioBytes = buffer->size;
+	buffer->xaBuffer.pAudioData = buffer->data;
+
+	if (buffer->loop)
+	{
+#ifdef _DEBUG
+		info("updateBufferNew: loop");
+#endif
+		// Note: Sega uses byte offsets for begin and end
+		//       Xaudio2 uses start sample and length in samples
+		buffer->xaBuffer.PlayBegin = buffer->startLoop / bufferSampleSize(buffer);
+		buffer->xaBuffer.PlayLength = (min(buffer->endLoop, buffer->endOffset) - buffer->startLoop) / bufferSampleSize(buffer);
+		buffer->xaBuffer.LoopBegin = buffer->xaBuffer.PlayBegin;
+		buffer->xaBuffer.LoopLength = buffer->xaBuffer.PlayLength;
+		buffer->xaBuffer.LoopCount = XAUDIO2_LOOP_INFINITE;
+		buffer->xaBuffer.pContext = NULL;
+	}
+	else
+	{
+#ifdef _DEBUG
+		info("updateBufferNew: no loop");
+#endif
+		buffer->xaBuffer.PlayBegin = buffer->startLoop / bufferSampleSize(buffer);
+		buffer->xaBuffer.PlayLength = (min(buffer->endLoop, buffer->endOffset) - buffer->startLoop) / bufferSampleSize(buffer);
+		buffer->xaBuffer.LoopBegin = 0;
+		buffer->xaBuffer.LoopLength = 0;
+		buffer->xaBuffer.LoopCount = 0;
+		buffer->xaBuffer.pContext = NULL;
+	}
+
+	buffer->xaVoice->SubmitSourceBuffer(&buffer->xaBuffer);
+
+	// Uncomment to dump audio buffers to wav files (super slow)
+	/*auto sampleBits = (buffer->sampleFormat == OPEN_HASF_SIGNED_16PCM) ? 16 : 8;
+	char path[255];
+	sprintf(path, "C:\\dump\\%08X.wav", &buffer);
+	dumpWaveBuffer(path, buffer->channels, buffer->sampleRate, sampleBits, buffer->data, buffer->size);*/
+}
+
 extern "C" {
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_CreateBuffer(OPEN_HAWOSEBUFFERCONFIG* pConfig, OPEN_HAWOSEGABUFFERCALLBACK pCallback,
-		unsigned int dwFlags, void* * phHandle)
+	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_CreateBuffer(OPEN_HAWOSEBUFFERCONFIG* pConfig, OPEN_HAWOSEGABUFFERCALLBACK pCallback, unsigned int dwFlags, void* * phHandle)
 	{
 		if ((phHandle == NULL) || (pConfig == NULL))
 		{
 			return OPENSEGAERR_BAD_POINTER;
 		}
 
-#ifdef _DEBUG
-		info("SEGAAPI_CreateBuffer: flags: %08X", dwFlags);;
-		info("pConfig Variables: SampleRate: %d, byNumChans: %d, dwPriority: %d, dwSampleFormat: %d", pConfig->dwSampleRate, pConfig->byNumChans, pConfig->dwPriority, pConfig->dwSampleFormat);
-#endif
-
 		OPEN_segaapiBuffer_t* buffer = new OPEN_segaapiBuffer_t;
+
+#ifdef _DEBUG
+		info("SEGAAPI_CreateBuffer: hHandle: %08X synth: %d, mem caller: %d, mem last: %d, mem alloc: %d, size: %d SampleRate: %d, byNumChans: %d, dwPriority: %d, dwSampleFormat: %d", buffer, (dwFlags & OPEN_HABUF_SYNTH_BUFFER), (dwFlags & OPEN_HABUF_ALLOC_USER_MEM) >> 1, (dwFlags & OPEN_HABUF_USE_MAPPED_MEM) >> 2, dwFlags == 0, pConfig->mapData.dwSize, pConfig->dwSampleRate, pConfig->byNumChans, pConfig->dwPriority, pConfig->dwSampleFormat);
+#endif
 
 		buffer->playing = false;
 		buffer->callback = pCallback;
@@ -504,14 +498,17 @@ extern "C" {
 		buffer->size = pConfig->mapData.dwSize;
 		pConfig->mapData.dwOffset = 0;
 
+		// Use buffer supplied by caller
 		if (dwFlags & OPEN_HABUF_ALLOC_USER_MEM)
 		{
 			buffer->data = (uint8_t*)pConfig->mapData.hBufferHdr;
 		}
+		// Reuse buffer
 		else if (dwFlags & OPEN_HABUF_USE_MAPPED_MEM)
 		{
 			buffer->data = (uint8_t*)pConfig->mapData.hBufferHdr;
 		}
+		// Allocate new buffer (caller will fill it later)
 		else
 		{
 			buffer->data = (uint8_t*)malloc(buffer->size);
@@ -524,7 +521,7 @@ extern "C" {
 		auto channels = pConfig->byNumChans;
 
 		buffer->xaFormat.cbSize = sizeof(WAVEFORMATEX);
-		buffer->xaFormat.nAvgBytesPerSec = (sampleRate * sampleBits * channels) / 8;;
+		buffer->xaFormat.nAvgBytesPerSec = (sampleRate * sampleBits * channels) / 8;
 		buffer->xaFormat.nSamplesPerSec = sampleRate;
 		buffer->xaFormat.wBitsPerSample = sampleBits;
 		buffer->xaFormat.nChannels = channels;
@@ -543,6 +540,7 @@ extern "C" {
 		resetBuffer(buffer);
 
 		*phHandle = buffer;
+		
 		return OPEN_SEGA_SUCCESS;
 	}
 
@@ -578,8 +576,7 @@ extern "C" {
 		return buffer->userData;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_UpdateBuffer(void* hHandle, unsigned int dwStartOffset,
-		unsigned int dwLength)
+	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_UpdateBuffer(void* hHandle, unsigned int dwStartOffset, unsigned int dwLength)
 	{
 		if (hHandle == NULL)
 		{
@@ -592,8 +589,7 @@ extern "C" {
 
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
 
-		updateBufferData(buffer, dwStartOffset, dwLength);
-		updateBufferLoop(buffer);
+		updateBufferNew(buffer, dwStartOffset, dwLength);
 		return OPEN_SEGA_SUCCESS;
 	}
 
@@ -662,8 +658,6 @@ extern "C" {
 		defer_buffer_call(buffer, [=]()
 		{
 			buffer->xaVoice->SetSourceSampleRate(dwSampleRate);
-
-			updateBufferLoop(buffer);
 		});
 
 		return OPEN_SEGA_SUCCESS;
@@ -682,11 +676,6 @@ extern "C" {
 
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
 		buffer->loop = bDoContinuousLooping;
-
-		defer_buffer_call(buffer, [=]()
-		{
-			updateBufferLoop(buffer);
-		});
 
 		return OPEN_SEGA_SUCCESS;
 	}
@@ -749,13 +738,17 @@ extern "C" {
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
 
 		updateRouting(buffer);
+		updateBufferNew(buffer, -1, -1);
 
-		updateBufferData(buffer, -1, -1);
-		updateBufferLoop(buffer);
-		updateSynthOnPlay(buffer, -1, -1);
 		buffer->playing = true;
 		buffer->paused = false;
-		CHECK_HR(buffer->xaVoice->Start());
+
+		// Uncomment to mute music
+		//if (buffer->playWithSetup)
+		//{
+			CHECK_HR(buffer->xaVoice->Start());
+		//}
+			
 		return OPEN_SEGA_SUCCESS;
 	}
 
@@ -872,11 +865,21 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
+	int SEGAAPI_SetGlobalEAXProperty(GUID * guid, unsigned long ulProperty, void * pData, unsigned long ulDataSize)
+	{
+#ifdef _DEBUG
+		info("SEGAAPI_SetGlobalEAXProperty:");
+#endif
+
+		// Everything is fine
+		return TRUE;
+	}
+
 	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Init(void)
 	{
 
 #ifdef _DEBUG
-		info("SEGAAPI_Init");
+		info("SEGAAPI_Init: hello harmfull world");
 #endif
 
 		CoInitialize(nullptr);
@@ -925,6 +928,7 @@ extern "C" {
 		setSubmixVoice(OPEN_HA_REAR_LEFT_PORT, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f);
 		setSubmixVoice(OPEN_HA_REAR_RIGHT_PORT, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f);
 		setSubmixVoice(OPEN_HA_LFE_PORT, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f);
+
 		return OPEN_SEGA_SUCCESS;
 	}
 
@@ -1010,8 +1014,7 @@ extern "C" {
 		}
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSendRouting(void* hHandle, unsigned int dwChannel, unsigned int dwSend,
-		OPEN_HAROUTING dwDest)
+	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSendRouting(void* hHandle, unsigned int dwChannel, unsigned int dwSend, OPEN_HAROUTING dwDest)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_SetSendRouting: hHandle: %08X dwChannel: %08X dwSend: %08X dwDest: %08X", hHandle, dwChannel, dwSend, dwDest);
@@ -1024,8 +1027,7 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSendLevel(void* hHandle, unsigned int dwChannel, unsigned int dwSend,
-		unsigned int dwLevel)
+	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSendLevel(void* hHandle, unsigned int dwChannel, unsigned int dwSend, unsigned int dwLevel)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_SetSendLevel: hHandle: %08X dwChannel: %08X dwSend: %08X dwLevel: %08X", hHandle, dwChannel, dwSend, dwLevel);
@@ -1140,25 +1142,42 @@ extern "C" {
 		int realParam = mapping[param];
 
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
-		tsf_hydra_genamount amount;
-		amount.shortAmount = lPARWValue;
-		tsf_region_operator(buffer->region, realParam, &amount);
+		//tsf_hydra_genamount amount;
+		//amount.shortAmount = lPARWValue;
+		//tsf_region_operator(buffer->region, realParam, &amount);
 
 		if (param == OPEN_HAVP_ATTENUATION)
 		{
-			float volume = tsf_decibelsToGain(0.0f - (amount.shortAmount / 10.0f));
+			float volume = tsf_decibelsToGain(0.0f - lPARWValue / 10.0f);
 
 			buffer->xaVoice->SetVolume(volume);
+#ifdef _DEBUG
+			info("SEGAAPI_SetSynthParam: OPEN_HAVP_ATTENUATION gain: %f dB: %d", volume, lPARWValue);
+#endif
 		}
 		else if (param == OPEN_HAVP_PITCH)
 		{
-			buffer->xaVoice->SetFrequencyRatio(XAudio2SemitonesToFrequencyRatio(lPARWValue / 100.0f));
+			float semiTones = lPARWValue / 100.0f;
+			float freqRatio = XAudio2SemitonesToFrequencyRatio(semiTones);
+
+			buffer->xaVoice->SetFrequencyRatio(freqRatio);
+#ifdef _DEBUG
+			info("SEGAAPI_SetSynthParam: OPEN_HAVP_PITCH hHandle: %08X semitones: %f freqRatio: %f", hHandle, semiTones, freqRatio);
+#endif
 		}
+
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSynthParamMultiple(void* hHandle, unsigned int dwNumParams,
-		OPEN_SynthParamSet* pSynthParams)
+	int SEGAAPI_GetSynthParam(void * hHandle, OPEN_HASYNTHPARAMSEXT param)
+	{
+#ifdef _DEBUG
+		info("SEGAAPI_GetSynthParam: hHandle: %08X OPEN_HASYNTHPARAMSEXT: %08X", hHandle, param);
+#endif
+		return 0; //todo not sure if actually used
+	}
+
+	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSynthParamMultiple(void* hHandle, unsigned int dwNumParams, OPEN_SynthParamSet* pSynthParams)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_SetSynthParamMultiple: hHandle: %08X dwNumParams: %08X pSynthParams: %08X", hHandle, dwNumParams, pSynthParams);
@@ -1170,8 +1189,7 @@ extern "C" {
 		return OPEN_SEGA_SUCCESS;
 	}
 
-	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetChannelVolume(void* hHandle, unsigned int dwChannel,
-		unsigned int dwVolume)
+	__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetChannelVolume(void* hHandle, unsigned int dwChannel, unsigned int dwVolume)
 	{
 #ifdef _DEBUG
 		info("SEGAAPI_SetChannelVolume: hHandle: %08X dwChannel: %08X dwVolume: %08X", hHandle, dwChannel, dwVolume);
@@ -1212,21 +1230,26 @@ extern "C" {
 	)
 	{
 #ifdef _DEBUG
-		info("SEGAAPI_PlayWithSetup: hHandle: %08X dwNumSendRouteParams: %08X pSendRouteParams: %08X dwNumSendLevelParams: %08X pSendLevelParams: %08X dwNumVoiceParams: %08X pVoiceParams: %08X dwNumSynthParams: %08X pSynthParams: %08X", hHandle, dwNumSendRouteParams, *pSendRouteParams, dwNumSendLevelParams, *pSendLevelParams, dwNumVoiceParams, *pVoiceParams, dwNumSynthParams, *pSynthParams);
+		info("SEGAAPI_PlayWithSetup: hHandle: %08X dwNumSendRouteParams: %d pSendRouteParams: %08X dwNumSendLevelParams: %d pSendLevelParams: %08X dwNumVoiceParams: %d pVoiceParams: %08X dwNumSynthParams: %d pSynthParams: %08X", hHandle, dwNumSendRouteParams, *pSendRouteParams, dwNumSendLevelParams, *pSendLevelParams, dwNumVoiceParams, *pVoiceParams, dwNumSynthParams, *pSynthParams);
+		info("dwNumSynthParams: %d", dwNumSynthParams);
 #endif
 		OPEN_segaapiBuffer_t* buffer = (OPEN_segaapiBuffer_t*)hHandle;
+		buffer->playWithSetup = true;
 
 		for (int i = 0; i < dwNumSendRouteParams; i++)
 		{
-			SEGAAPI_SetSendRouting(hHandle, pSendRouteParams[i].dwChannel, pSendRouteParams[i].dwSend,
-				pSendRouteParams[i].dwDest);
+			SEGAAPI_SetSendRouting(hHandle, pSendRouteParams[i].dwChannel, pSendRouteParams[i].dwSend, pSendRouteParams[i].dwDest);
 		}
 
 		for (int i = 0; i < dwNumSendLevelParams; i++)
 		{
-			SEGAAPI_SetSendLevel(hHandle, pSendLevelParams[i].dwChannel, pSendLevelParams[i].dwSend,
-				pSendLevelParams[i].dwLevel);
+			SEGAAPI_SetSendLevel(hHandle, pSendLevelParams[i].dwChannel, pSendLevelParams[i].dwSend, pSendLevelParams[i].dwLevel);
 		}
+
+		unsigned int loopStart = 0;
+		unsigned int loopEnd = 0;
+		unsigned int loopState = 0;
+		unsigned int endOffset = 0;
 
 		for (int i = 0; i < dwNumVoiceParams; i++)
 		{
@@ -1234,24 +1257,41 @@ extern "C" {
 			{
 			case OPEN_VOICEIOCTL_SET_START_LOOP_OFFSET:
 				SEGAAPI_SetStartLoopOffset(hHandle, pVoiceParams[i].dwParam1);
+				loopStart = pVoiceParams[i].dwParam1;
 				break;
 			case OPEN_VOICEIOCTL_SET_END_LOOP_OFFSET:
 				SEGAAPI_SetEndLoopOffset(hHandle, pVoiceParams[i].dwParam1);
+				loopEnd = pVoiceParams[i].dwParam1;
 				break;
 			case OPEN_VOICEIOCTL_SET_END_OFFSET:
 				SEGAAPI_SetEndOffset(hHandle, pVoiceParams[i].dwParam1);
+				endOffset = pVoiceParams[i].dwParam1;
 				break;
 			case OPEN_VOICEIOCTL_SET_LOOP_STATE:
 				SEGAAPI_SetLoopState(hHandle, pVoiceParams[i].dwParam1);
+				loopState = pVoiceParams[i].dwParam1;
 				break;
 			case OPEN_VOICEIOCTL_SET_NOTIFICATION_POINT:
+#ifdef _DEBUG
+				info("Unimplemented! OPEN_VOICEIOCTL_SET_NOTIFICATION_POINT");
+#endif
 				break;
 			case OPEN_VOICEIOCTL_CLEAR_NOTIFICATION_POINT:
+#ifdef _DEBUG
+				info("Unimplemented! OPEN_VOICEIOCTL_CLEAR_NOTIFICATION_POINT");
+#endif
 				break;
 			case OPEN_VOICEIOCTL_SET_NOTIFICATION_FREQUENCY:
+#ifdef _DEBUG
+				info("Unimplemented! OPEN_VOICEIOCTL_SET_NOTIFICATION_FREQUENCY");
+#endif
 				break;
 			}
 		}
+
+#ifdef _DEBUG
+		info("loopdata\t%08X\t%08X\t%08X\t%08X\t%d\t%d", hHandle, loopStart, loopEnd, endOffset, loopState, buffer->size);
+#endif
 
 		for (int i = 0; i < dwNumSynthParams; i++)
 		{

--- a/Opensegaapi/src/opensegaapi.h
+++ b/Opensegaapi/src/opensegaapi.h
@@ -10,10 +10,10 @@
 // TODO: DOCUMENT ALL THESE ACCORDING TO ORIGINAL DOCUMENTS!!!!
 
 #define OPEN_SEGA_SUCCESS 0L
-typedef int OPENSEGASTATUS;
-#define OPENSEGARESULT_FAILURE(_x)      ((1 << 31) | 0xA000 | (_x))
-#define OPENSEGAERR_BAD_HANDLE                    OPENSEGARESULT_FAILURE(18)
-#define OPENSEGAERR_BAD_POINTER                   OPENSEGARESULT_FAILURE(3)
+typedef int OPEN_SEGASTATUS;
+#define OPEN_SEGARESULT_FAILURE(_x)      ((1 << 31) | 0xA000 | (_x))
+#define OPEN_SEGAERR_BAD_HANDLE                    OPEN_SEGARESULT_FAILURE(18)
+#define OPEN_SEGAERR_BAD_POINTER                   OPEN_SEGARESULT_FAILURE(3)
 
 // SEGA custom EAX40 properties.
 // GUID: {A7FEEC3F-2BFD-4a40-891F-7423E38BAC1F}
@@ -40,7 +40,7 @@ typedef enum
 	OPEN_HAWOSTATUS_INVALID = -1
 } OPEN_HAWOSTATUS;
 
-#define OPEN_HABUF_SYNTH_BUFFER		0x00000001
+#define OPEN_HABUF_SYNTH_BUFFER      0x00000001
 #define OPEN_HABUF_ALLOC_USER_MEM    0x00000002
 #define OPEN_HABUF_USE_MAPPED_MEM    0x00000004
 #define OPEN_HASF_UNSIGNED_8PCM      0x0004
@@ -181,50 +181,50 @@ typedef struct OPEN_SynthParamSetExt
 	int lPARWValue;
 } OPEN_SynthParamSet;
 
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Play(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Pause(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Stop(void* hHandle);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Play(void* hHandle);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Pause(void* hHandle);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Stop(void* hHandle);
 __declspec(dllexport) OPEN_HAWOSTATUS SEGAAPI_GetPlaybackStatus(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetFormat(void* hHandle, OPEN_HAWOSEFORMAT* pFormat);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_GetFormat(void* hHandle, OPEN_HAWOSEFORMAT* pFormat);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSampleRate(void* hHandle, unsigned int dwSampleRate);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetFormat(void* hHandle, OPEN_HAWOSEFORMAT* pFormat);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_GetFormat(void* hHandle, OPEN_HAWOSEFORMAT* pFormat);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSampleRate(void* hHandle, unsigned int dwSampleRate);
 __declspec(dllexport) unsigned int SEGAAPI_GetSampleRate(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetPriority(void* hHandle, unsigned int dwPriority);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetPriority(void* hHandle, unsigned int dwPriority);
 __declspec(dllexport) unsigned int SEGAAPI_GetPriority(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetUserData(void* hHandle, void* hUserData);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetUserData(void* hHandle, void* hUserData);
 __declspec(dllexport) void* SEGAAPI_GetUserData(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSendRouting(void* hHandle, unsigned int dwChannel, unsigned int dwSend,
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSendRouting(void* hHandle, unsigned int dwChannel, unsigned int dwSend,
 	OPEN_HAROUTING dwDest);
 __declspec(dllexport) OPEN_HAROUTING SEGAAPI_GetSendRouting(void* hHandle, unsigned int dwChannel, unsigned int dwSend);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSendLevel(void* hHandle, unsigned int dwChannel, unsigned int dwSend,
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSendLevel(void* hHandle, unsigned int dwChannel, unsigned int dwSend,
 	unsigned int dwLevel);
 __declspec(dllexport) unsigned int SEGAAPI_GetSendLevel(void* hHandle, unsigned int dwChannel, unsigned int dwSend);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetChannelVolume(void* hHandle, unsigned int dwChannel,
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetChannelVolume(void* hHandle, unsigned int dwChannel,
 	unsigned int dwVolume);
 __declspec(dllexport) unsigned int SEGAAPI_GetChannelVolume(void* hHandle, unsigned int dwChannel);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetPlaybackPosition(void* hHandle, unsigned int dwPlaybackPos);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetPlaybackPosition(void* hHandle, unsigned int dwPlaybackPos);
 __declspec(dllexport) unsigned int SEGAAPI_GetPlaybackPosition(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetNotificationFrequency(void* hHandle, unsigned int dwFrameCount);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetNotificationPoint(void* hHandle, unsigned int dwBufferOffset);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_ClearNotificationPoint(void* hHandle, unsigned int dwBufferOffset);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetStartLoopOffset(void* hHandle, unsigned int dwOffset);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetNotificationFrequency(void* hHandle, unsigned int dwFrameCount);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetNotificationPoint(void* hHandle, unsigned int dwBufferOffset);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_ClearNotificationPoint(void* hHandle, unsigned int dwBufferOffset);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetStartLoopOffset(void* hHandle, unsigned int dwOffset);
 __declspec(dllexport) unsigned int SEGAAPI_GetStartLoopOffset(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetEndLoopOffset(void* hHandle, unsigned int dwOffset);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetEndLoopOffset(void* hHandle, unsigned int dwOffset);
 __declspec(dllexport) unsigned int SEGAAPI_GetEndLoopOffset(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetEndOffset(void* hHandle, unsigned int dwOffset);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetEndOffset(void* hHandle, unsigned int dwOffset);
 __declspec(dllexport) unsigned int SEGAAPI_GetEndOffset(void* hHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetLoopState(void* hHandle, int bDoContinuousLooping);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetLoopState(void* hHandle, int bDoContinuousLooping);
 __declspec(dllexport)int SEGAAPI_GetLoopState(void* hHandle);
-__declspec(dllexport)OPENSEGASTATUS SEGAAPI_UpdateBuffer(void* hHandle, unsigned int dwStartOffset,
+__declspec(dllexport)OPEN_SEGASTATUS SEGAAPI_UpdateBuffer(void* hHandle, unsigned int dwStartOffset,
 	unsigned int dwLength);
-__declspec(dllexport)OPENSEGASTATUS SEGAAPI_SetSynthParam(void* hHandle, OPEN_HASYNTHPARAMSEXT param, int lPARWValue);
+__declspec(dllexport)OPEN_SEGASTATUS SEGAAPI_SetSynthParam(void* hHandle, OPEN_HASYNTHPARAMSEXT param, int lPARWValue);
 __declspec(dllexport) int SEGAAPI_GetSynthParam(void* hHandle, OPEN_HASYNTHPARAMSEXT param);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSynthParamMultiple(void* hHandle, unsigned int dwNumParams,
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSynthParamMultiple(void* hHandle, unsigned int dwNumParams,
 	OPEN_SynthParamSet* pSynthParams);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_GetSynthParamMultiple(void* hHandle, unsigned int dwNumParams,
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_GetSynthParamMultiple(void* hHandle, unsigned int dwNumParams,
 	OPEN_SynthParamSet* pSynthParams);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetReleaseState(void* hHandle, int bSet);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_PlayWithSetup(
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetReleaseState(void* hHandle, int bSet);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_PlayWithSetup(
 	void* hHandle,
 	unsigned int dwNumSendRouteParams, OPEN_SendRouteParamSet* pSendRouteParams,
 	unsigned int dwNumSendLevelParams, OPEN_SendLevelParamSet* pSendLevelParams,
@@ -233,31 +233,31 @@ __declspec(dllexport) OPENSEGASTATUS SEGAAPI_PlayWithSetup(
 );
 typedef void(*OPEN_HAWOSEGABUFFERCALLBACK)(void* hHandle,
 	OPEN_HAWOSMESSAGETYPE message);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_CreateBuffer(OPEN_HAWOSEBUFFERCONFIG* pConfig,
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_CreateBuffer(OPEN_HAWOSEBUFFERCONFIG* pConfig,
 	OPEN_HAWOSEGABUFFERCALLBACK pCallback,
 	unsigned int dwFlags,
 	void* * phHandle);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_DestroyBuffer(void* hHandle);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_DestroyBuffer(void* hHandle);
 __declspec(dllexport) int SEGAAPI_SetGlobalEAXProperty(GUID* guid, unsigned long ulProperty, void* pData,
 	unsigned long ulDataSize);
 __declspec(dllexport) int SEGAAPI_GetGlobalEAXProperty(GUID* guid, unsigned long ulProperty, void* pData,
 	unsigned long ulDataSize);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSPDIFOutChannelStatus(
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSPDIFOutChannelStatus(
 	unsigned int dwChannelStatus,
 	unsigned int dwExtChannelStatus);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_GetSPDIFOutChannelStatus(
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_GetSPDIFOutChannelStatus(
 	unsigned int* pdwChannelStatus,
 	unsigned int* pdwExtChannelStatus);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSPDIFOutSampleRate(OPEN_HASPDIFOUTRATE dwSamplingRate);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSPDIFOutSampleRate(OPEN_HASPDIFOUTRATE dwSamplingRate);
 __declspec(dllexport) OPEN_HASPDIFOUTRATE SEGAAPI_GetSPDIFOutSampleRate(void);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetSPDIFOutChannelRouting(
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetSPDIFOutChannelRouting(
 	unsigned int dwChannel,
 	OPEN_HAROUTING dwSource);
 __declspec(dllexport) OPEN_HAROUTING SEGAAPI_GetSPDIFOutChannelRouting(unsigned int dwChannel);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_SetIOVolume(OPEN_HAPHYSICALIO dwPhysIO, unsigned int dwVolume);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_SetIOVolume(OPEN_HAPHYSICALIO dwPhysIO, unsigned int dwVolume);
 __declspec(dllexport) unsigned int SEGAAPI_GetIOVolume(OPEN_HAPHYSICALIO dwPhysIO);
-__declspec(dllexport) void SEGAAPI_SetLastStatus(OPENSEGASTATUS LastStatus);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_GetLastStatus(void);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Reset(void);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Init(void);
-__declspec(dllexport) OPENSEGASTATUS SEGAAPI_Exit(void);
+__declspec(dllexport) void SEGAAPI_SetLastStatus(OPEN_SEGASTATUS LastStatus);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_GetLastStatus(void);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Reset(void);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Init(void);
+__declspec(dllexport) OPEN_SEGASTATUS SEGAAPI_Exit(void);


### PR DESCRIPTION
This fixes broken sound in alot of Lindbergh games.
The main reason for this is because this PR implements sound sprites.
Sound sprites are long audio buffers where parts are used/looped to create sound effects.

Games I tested and confirmed it works:
- HOTD4
- ID4
- ID5
- OR2
- SRTV

I left some comments and logs for future devs.